### PR TITLE
Stop syncing university email

### DIFF
--- a/lib/banner/affiliations/employee.rb
+++ b/lib/banner/affiliations/employee.rb
@@ -3,7 +3,7 @@ module Banner
     SQL_ALL = "SELECT * FROM bpv_current_employees WHERE ecls NOT IN(30,31,33,51,52) AND id NOT LIKE 'X%' AND id NOT LIKE 'Z%'"
     SQL_ONE = "SELECT * FROM bpv_current_employees WHERE ecls NOT IN(30,31,33,51,52) AND id = :1"
 
-    ATTRS = superclass::ATTRS + [:pay_type, :department, :title, :office_phone, :full_time, :employee_type]
+    ATTRS = ATTRS + [:pay_type, :department, :title, :office_phone, :full_time, :employee_type]
 
     default_readers({
       pay_type:       :PAYID,

--- a/lib/banner/affiliations/student.rb
+++ b/lib/banner/affiliations/student.rb
@@ -5,7 +5,7 @@ module Banner
     SQL_ALL = "SELECT * FROM bsv_trogdir_student"
     SQL_ONE = "SELECT * FROM bsv_trogdir_student WHERE id = :1"
 
-    ATTRS = superclass::ATTRS + [:majors, :minors, :mailbox]
+    ATTRS = ATTRS + [:majors, :minors, :mailbox]
 
     default_readers({
       mailbox:  :MAILBOX,

--- a/lib/banner/person.rb
+++ b/lib/banner/person.rb
@@ -10,8 +10,7 @@ module Banner
       street_2:         :STREET2,
       city:             :CITY,
       state:            :STATE,
-      zip:              :ZIP,
-      university_email: :EMAIL
+      zip:              :ZIP
     })
 
     def biola_id
@@ -32,6 +31,7 @@ module Banner
     end
 
     def self.find(biola_id)
+      raise NotImplementedError, 'self::SQL_ONE must be defined' unless defined? self::SQL_ONE
       sql = self::SQL_ONE
       params = {1 => biola_id.to_s.rjust(8, '0')}
 

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -1,12 +1,10 @@
 class Person
-  # TODO: we may be able to ignore university_email since it should be handled by something other than Banner
   # Attributes that are common to all types of people
   ATTRS = [
     :banner_id, :biola_id,
     :last_name, :first_name, :middle_name, :preferred_name,
     :gender, :privacy,
-    :street_1, :street_2, :city, :state, :zip,
-    :university_email
+    :street_1, :street_2, :city, :state, :zip
   ]
 
   ATTRS.each do |attr|

--- a/lib/person_synchronizer.rb
+++ b/lib/person_synchronizer.rb
@@ -18,7 +18,7 @@ class PersonSynchronizer
 
       change_address!
 
-      {university: :university_email, personal: :personal_email}.each do |type, att|
+      {personal: :personal_email}.each do |type, att|
         if both_respond_to? att
           change_email! type, att
         end

--- a/lib/trogdir/person.rb
+++ b/lib/trogdir/person.rb
@@ -7,7 +7,7 @@ module Trogdir
       :partial_ssn, :birth_date, :country, :personal_email,
 
       # IDs needed to do updates and destroys against the Trogdir API
-      :banner_id_id, :biola_id_id, :address_id, :university_email_id, :personal_email_id
+      :banner_id_id, :biola_id_id, :address_id, :personal_email_id
     ]
 
     default_readers({
@@ -47,10 +47,6 @@ module Trogdir
       end
     end
 
-    def university_email
-      find(:emails, :university)[:address]
-    end
-
     def personal_email
       find(:emails, :personal)[:address]
     end
@@ -65,10 +61,6 @@ module Trogdir
 
     def address_id
       home_address[:id]
-    end
-
-    def university_email_id
-      find(:emails, :university)[:id]
     end
 
     def personal_email_id

--- a/spec/lib/banner_syncinator/banner/person_spec.rb
+++ b/spec/lib/banner_syncinator/banner/person_spec.rb
@@ -71,12 +71,6 @@ describe Banner::Person do
     it{ expect(person.zip).to eql '12345' }
   end
 
-  describe '#university_email' do
-    let(:params) { {EMAIL: 'coach.z@example.com'} }
-    its(:university_email) { should eql 'coach.z@example.com' }
-    it{ expect(person.university_email).to eql 'coach.z@example.com' }
-  end
-
   describe '#gender' do
     context "when 'M'" do
       let(:params) { {GENDER: 'M'} }

--- a/spec/lib/banner_syncinator/person_synchronizer_spec.rb
+++ b/spec/lib/banner_syncinator/person_synchronizer_spec.rb
@@ -121,7 +121,7 @@ describe PersonSynchronizer do
     end
 
     context 'when creating an email' do
-      let(:more_new_attrs) { {EMAIL: 'john.doe@biola.edu'} }
+      let(:more_new_attrs) { {EMAIL_PERS: 'john.doe@example.com'} }
 
       it 'calls email_api :create' do
         expect(subject).to receive(:email_api).with(:create, kind_of(Hash))
@@ -130,8 +130,8 @@ describe PersonSynchronizer do
     end
 
     context 'when updating an email' do
-      let(:more_old_attrs) { {emails: [{id: 123, type: 'university', address: 'john.doe@biola.edu'}]} }
-      let(:more_new_attrs) { {EMAIL: 'jonny.doe@biola.edu'} }
+      let(:more_old_attrs) { {emails: [{id: 123, type: 'personal', address: 'john.doe@example.com'}]} }
+      let(:more_new_attrs) { {EMAIL_PERS: 'jonny.doe@example.com'} }
 
       it 'calls id_api :update' do
         expect(subject).to receive(:email_api).with(:update, kind_of(Hash))
@@ -140,8 +140,8 @@ describe PersonSynchronizer do
     end
 
     context 'when removing an email' do
-      let(:more_old_attrs) { {emails: [{id: 123, type: 'university', address: 'john.doe@biola.edu'}]} }
-      let(:more_new_attrs) { {EMAIL: nil} }
+      let(:more_old_attrs) { {emails: [{id: 123, type: 'personal', address: 'john.doe@example.com'}]} }
+      let(:more_new_attrs) { {EMAIL_PERS: nil} }
 
       it 'calls id_api :destroy' do
         expect(subject).to receive(:email_api).with(:destroy, kind_of(Hash))

--- a/spec/lib/banner_syncinator/trogdir/person_spec.rb
+++ b/spec/lib/banner_syncinator/trogdir/person_spec.rb
@@ -74,11 +74,6 @@ describe Trogdir::Person do
     its(:country) { should eql 'USA' }
   end
 
-  describe '#university_email' do
-    let(:params) { {emails: [{type: 'university', address: 'coach.z@example.com'}]} }
-    its(:university_email) { should eql 'coach.z@example.com' }
-  end
-
   describe '#personal_email' do
     let(:params) { {emails: [{type: 'personal', address: 'dacoach@example.com'}]} }
     its(:personal_email) { should eql 'dacoach@example.com' }
@@ -143,11 +138,6 @@ describe Trogdir::Person do
   describe '#address_id' do
     let(:params) { {addresses: [{type: 'home', id: 3}]} }
     its(:address_id) { should eql 3 }
-  end
-
-  describe '#university_email_id' do
-    let(:params) { {emails: [{type: 'university', id: 4}]} }
-    its(:university_email_id) { should eql 4 }
   end
 
   describe '#personal_email_id' do


### PR DESCRIPTION
University email will now be set by google-syncinator so we don't need to sync in in from Banner anymore.