### PR TITLE
Properly mark changes as skipped

### DIFF
--- a/lib/workers/handle_change.rb
+++ b/lib/workers/handle_change.rb
@@ -48,7 +48,7 @@ module Workers
         end
 
         if action == :skip
-          Log.info "No changes needed for person #{change.person_uuid}" if action == :skip
+          Log.info "No changes needed for person #{change.person_uuid}"
           Workers::ChangeFinish.perform_async change.sync_log_id, action
         end
       rescue StandardError => err

--- a/lib/workers/handle_change.rb
+++ b/lib/workers/handle_change.rb
@@ -45,7 +45,9 @@ module Workers
             Log.info "No pidm found for  #{change.person_uuid}"
             Workers::ChangeFinish.perform_async change.sync_log_id, action
           end
+        end
 
+        if action == :skip
           Log.info "No changes needed for person #{change.person_uuid}" if action == :skip
           Workers::ChangeFinish.perform_async change.sync_log_id, action
         end


### PR DESCRIPTION
If the netid isn't changed, banner-syncinator should properly send the
skip message to trogdir so changes don't hang in pending limbo.