### PR TITLE
Updating cron schedule to spread out when jobs run.

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -2,27 +2,27 @@
 ####### Affiliations #########
 ##############################
 AcceptedStudents:
-  cron: "0 08-17 * * 1-5"
+  cron: "30 08-17 * * 1-5"
   class: "Workers::Affiliations::AcceptedStudents"
   queue: default
 
 Alumni:
-  cron: "0 8 * * 1"
+  cron: "0 1 * * *"
   class: "Workers::Affiliations::Alumni"
   queue: default
 
 Employees:
-  cron: "0 08-17 * * 1-5"
+  cron: "10 08-17 * * 1-5"
   class: "Workers::Affiliations::Employees"
   queue: default
 
 Faculty:
-  cron: "0 08-17 * * 1-5"
+  cron: "20 08-17 * * 1-5"
   class: "Workers::Affiliations::Faculty"
   queue: default
 
 StudentWorkers:
-  cron: "0 08-17 * * 1-5"
+  cron: "40 08-17 * * 1-5"
   class: "Workers::Affiliations::StudentWorkers"
   queue: default
 
@@ -32,12 +32,12 @@ Students:
   queue: default
 
 Trustees:
-  cron: "0 8 * * *"
+  cron: "0 4 * * *"
   class: "Workers::Affiliations::Trustees"
   queue: default
 
 Volunteers:
-  cron: "0 8 * * *"
+  cron: "0 5 * * *"
   class: "Workers::Affiliations::Volunteers"
   queue: default
 
@@ -46,17 +46,17 @@ Volunteers:
 ##############################
 
 ClassLevel:
-  cron: "0 8 * * *"
+  cron: "0 18 * * *"
   class: "Workers::Groups::ClassLevel"
   queue: default
 
 International:
-  cron: "0 8 * * *"
+  cron: "0 19 * * *"
   class: "Workers::Groups::International"
   queue: default
 
 Residence:
-  cron: "0 08 * * 1"
+  cron: "0 20 * * 1"
   class: "Workers::Groups::Residence"
   queue: default
 


### PR DESCRIPTION
We are getting conflict issues from different affiliations syncs running at the same time.
Also changing the alumni sync to run every day.